### PR TITLE
把點擊音效從GameButton分離出來，但仍保留能自訂點擊音效的功能

### DIFF
--- a/include/GameButton.hpp
+++ b/include/GameButton.hpp
@@ -6,6 +6,10 @@
 
 class GameButton : public GameObjectEx{
 public:
+    explicit GameButton();
+
+    explicit GameButton(const std::function<void()>& click_sound);
+
     void AddOnClickCallBack(const std::function<void()>& func);
 
     void Update();
@@ -16,17 +20,15 @@ public:
 
     void SetZIndex(float index);
 
-    void SetClickSound(const std::string &sound_path);
-
 private:
-    bool IsMouseHovering();
+    static inline std::unique_ptr<Util::SFX> s_ClickSound = nullptr;
+
+    bool IsMouseHovering() const;
 
     std::vector<std::function<void()>> m_OnClickCallBacks;
     std::shared_ptr<AnimatedGameObject> m_HoverBorder;
-    std::unique_ptr<Util::SFX> m_Sound;
 };
 
 std::shared_ptr<GameButton>
 CreateGameYellowButton(const std::string &btn_path,
-                       std::initializer_list<std::string> border_paths,
-                       const std::string &sound_path);
+                       std::initializer_list<std::string> border_paths);

--- a/src/CatBase.cpp
+++ b/src/CatBase.cpp
@@ -22,8 +22,7 @@ CatBaseScene::CatBaseScene(App &app)
     m_BackButton = CreateGameYellowButton(
         RESOURCE_DIR "/buttons/button_back_ipad.png",
         {RESOURCE_DIR "/buttons/button_back_yellow.png",
-         RESOURCE_DIR "/buttons/button_back_purple.png"},
-        RESOURCE_DIR"/sounds/click.mp3");
+         RESOURCE_DIR "/buttons/button_back_purple.png"});
     m_BackButton->SetZIndex(0.5f);
     m_BackButton->SetPosition(-200.0f, -200.0f);
     m_BackButton->AddOnClickCallBack([this] {

--- a/src/GameButton.cpp
+++ b/src/GameButton.cpp
@@ -3,7 +3,23 @@
 #include "Utility.hpp"
 #include "Util/BGM.hpp"
 
-void GameButton::AddOnClickCallBack(const std::function<void()>& func) {
+GameButton::GameButton() {
+    if (!s_ClickSound) {
+        s_ClickSound = std::make_unique<Util::SFX>(RESOURCE_DIR "/sounds/click.mp3");
+    }
+
+    AddOnClickCallBack([] { 
+        s_ClickSound->Play(); 
+    });
+}
+
+GameButton::GameButton(const std::function<void()>& click_sound) {
+    if (click_sound) {
+        AddOnClickCallBack(click_sound);
+    }
+}
+
+void GameButton::AddOnClickCallBack(const std::function<void()> &func) {
     m_OnClickCallBacks.push_back(func);
 }
 
@@ -16,7 +32,6 @@ void GameButton::Update() {
         m_HoverBorder->SetVisible(true);
         m_HoverBorder->Play();
         if (Util::Input::IsKeyDown(Util::Keycode::MOUSE_LB)) {
-            m_Sound->Play();
             for (const auto &callback : m_OnClickCallBacks) {
                 callback();
             }
@@ -46,11 +61,7 @@ void GameButton::SetZIndex(const float index) {
     m_HoverBorder->SetZIndex(index + 0.001f);
 }
 
-void GameButton::SetClickSound(const std::string &sound_path) {
-    m_Sound = std::make_unique<Util::SFX>(sound_path);
-}
-
-bool GameButton::IsMouseHovering() {
+bool GameButton::IsMouseHovering() const {
     const auto size = GetScaledSize();
     const auto top_left_pos = GetTransform().translation - size / 2.0f;
     return PointInRect(top_left_pos, size, Util::Input::GetCursorPosition());
@@ -58,8 +69,7 @@ bool GameButton::IsMouseHovering() {
 
 std::shared_ptr<GameButton>
 CreateGameYellowButton(const std::string &btn_path,
-                       std::initializer_list<std::string> border_paths,
-                       const std::string &sound_path) {
+                       std::initializer_list<std::string> border_paths) {
     auto button = std::make_unique<GameButton>();
     button->SetDrawable(std::make_shared<Util::Image>(btn_path));
 
@@ -75,7 +85,6 @@ CreateGameYellowButton(const std::string &btn_path,
 
 
     button->SetHoverBorder(border);
-    button->SetClickSound(sound_path);
 
     return button;
 }

--- a/src/MenuScene.cpp
+++ b/src/MenuScene.cpp
@@ -20,8 +20,7 @@ MenuScene::MenuScene(App &app) : m_App(app) {
 
     m_StartButton = CreateGameYellowButton(RESOURCE_DIR"/buttons/YellowButton.png",
                                            {RESOURCE_DIR"/buttons/YellowButton_p.png",
-                                            RESOURCE_DIR"/buttons/YellowButton_y.png"},
-                                           RESOURCE_DIR"/sounds/click.mp3");
+                                            RESOURCE_DIR"/buttons/YellowButton_y.png"});
     m_StartButton->SetZIndex(0.6);
     m_StartButton->SetPosition(0.0f, -75.0f);
     m_StartButton->AddOnClickCallBack([this] { 


### PR DESCRIPTION
因為遊戲內大多能點擊的UI的音效都一樣，所以把那個SFX獨立出來，這樣就不需要每建造一個新的Button就讀取一次同一個mp3檔