### PR TITLE
gameover sound bug fix

### DIFF
--- a/include/Sound.hpp
+++ b/include/Sound.hpp
@@ -1,6 +1,7 @@
 #ifndef BATTLECAT_SOUND_HPP
 #define BATTLECAT_SOUND_HPP
 #include "Util/SFX.hpp"
+#include "Util/BGM.hpp"
 
 namespace Sounds {
     const std::unique_ptr<Util::SFX> Attack1 = std::make_unique<Util::SFX>(RESOURCE_DIR "/sounds/attack1.mp3");
@@ -11,13 +12,15 @@ namespace Sounds {
     const std::unique_ptr<Util::SFX> ButtonClick = std::make_unique<Util::SFX>(RESOURCE_DIR "/sounds/click.mp3");
     const std::unique_ptr<Util::SFX> Crit = std::make_unique<Util::SFX>(RESOURCE_DIR "/sounds/critical.mp3");
     const std::unique_ptr<Util::SFX> Death = std::make_unique<Util::SFX>(RESOURCE_DIR "/sounds/death.mp3");
-    const std::unique_ptr<Util::SFX> Defeat = std::make_unique<Util::SFX>(RESOURCE_DIR "/sounds/defeat.mp3");
+    const std::unique_ptr<Util::BGM> Defeat = std::make_unique<Util::BGM>(RESOURCE_DIR "/sounds/defeat.mp3");
+    //const std::unique_ptr<Util::SFX> Defeat = std::make_unique<Util::SFX>(RESOURCE_DIR "/sounds/defeat.mp3");
     const std::unique_ptr<Util::SFX> Deploy = std::make_unique<Util::SFX>(RESOURCE_DIR "/sounds/deploy.mp3");
     const std::unique_ptr<Util::SFX> Recharge = std::make_unique<Util::SFX>(RESOURCE_DIR "/sounds/recharge.mp3");
     const std::unique_ptr<Util::SFX> Reward = std::make_unique<Util::SFX>(RESOURCE_DIR "/sounds/reward.mp3");
     const std::unique_ptr<Util::SFX> Scrolling = std::make_unique<Util::SFX>(RESOURCE_DIR "/sounds/scrolling.mp3");
     const std::unique_ptr<Util::SFX> UsingItem = std::make_unique<Util::SFX>(RESOURCE_DIR "/sounds/using.mp3");
-    const std::unique_ptr<Util::SFX> Victory = std::make_unique<Util::SFX>(RESOURCE_DIR "/sounds/victory.mp3");
+    const std::unique_ptr<Util::BGM> Victory = std::make_unique<Util::BGM>(RESOURCE_DIR "/sounds/victory.mp3");
+    //const std::unique_ptr<Util::SFX> Victory = std::make_unique<Util::SFX>(RESOURCE_DIR "/sounds/victory.mp3");
 }
 
 #endif // BATTLECAT_SOUND_HPP


### PR DESCRIPTION
修復戰鬥結束後不會撥放勝利/戰敗音樂的問題
(可能是由於hit音效播放地太頻繁，把結束音樂從原本的SFX類別改成BGM就行)